### PR TITLE
Use Custom RPC Endpoint for Rinkeby

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,18 +27,21 @@ import '@rainbow-me/rainbowkit/styles.css'
 import { isProdRinkeby } from '@/connectors'
 
 let configuredChains = []
+let configuredProviders = []
 if (isProdRinkeby) {
   configuredChains = [chain.rinkeby]
+  configuredProviders = [publicProvider()]
 } else if (isRinkeby) {
   configuredChains = [chain.rinkeby, chain.hardhat]
+  configuredProviders = [publicProvider(), publicProvider()]
 } else {
   configuredChains = [chain.mainnet]
+  configuredProviders = [
+    alchemyProvider({ apiKey: process.env.REACT_APP_NETWORK_URL_MAINNET.slice(-32) }),
+  ]
 }
 
-const { chains, provider } = configureChains(configuredChains, [
-  alchemyProvider({ apiKey: process.env.REACT_APP_NETWORK_URL_MAINNET.slice(-32) }),
-  publicProvider(),
-])
+const { chains, provider } = configureChains(configuredChains, configuredProviders)
 
 const { connectors } = getDefaultWallets({
   appName: 'Arbor',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,8 +7,9 @@ import { RainbowKitProvider, Theme, darkTheme, getDefaultWallets } from '@rainbo
 import { merge } from 'lodash'
 import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
-import { WagmiConfig, chain, configureChains, createClient } from 'wagmi'
+import { WagmiConfig, chain, chainId, configureChains, createClient } from 'wagmi'
 import { alchemyProvider } from 'wagmi/providers/alchemy'
+import { jsonRpcProvider } from 'wagmi/providers/jsonRpc'
 import { publicProvider } from 'wagmi/providers/public'
 
 import { MobileBlocker } from './components/MobileBlocker'
@@ -27,21 +28,24 @@ import '@rainbow-me/rainbowkit/styles.css'
 import { isProdRinkeby } from '@/connectors'
 
 let configuredChains = []
-let configuredProviders = []
 if (isProdRinkeby) {
   configuredChains = [chain.rinkeby]
-  configuredProviders = [publicProvider()]
 } else if (isRinkeby) {
   configuredChains = [chain.rinkeby, chain.hardhat]
-  configuredProviders = [publicProvider(), publicProvider()]
 } else {
   configuredChains = [chain.mainnet]
-  configuredProviders = [
-    alchemyProvider({ apiKey: process.env.REACT_APP_NETWORK_URL_MAINNET.slice(-32) }),
-  ]
 }
 
-const { chains, provider } = configureChains(configuredChains, configuredProviders)
+const { chains, provider } = configureChains(configuredChains, [
+  alchemyProvider({ apiKey: process.env.REACT_APP_NETWORK_URL_MAINNET.slice(-32) }),
+  jsonRpcProvider({
+    rpc: (chain) => {
+      if (chain.id !== chainId.rinkeby) return null
+      return { http: process.env.REACT_APP_NETWORK_URL_RINKEBY }
+    },
+  }),
+  publicProvider(),
+])
 
 const { connectors } = getDefaultWallets({
   appName: 'Arbor',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,13 +37,13 @@ if (isProdRinkeby) {
 }
 
 const { chains, provider } = configureChains(configuredChains, [
-  alchemyProvider({ apiKey: process.env.REACT_APP_NETWORK_URL_MAINNET.slice(-32) }),
   jsonRpcProvider({
     rpc: (chain) => {
       if (chain.id !== chainId.rinkeby) return null
       return { http: process.env.REACT_APP_NETWORK_URL_RINKEBY }
     },
   }),
+  alchemyProvider({ apiKey: process.env.REACT_APP_NETWORK_URL_MAINNET.slice(-32) }),
   publicProvider(),
 ])
 


### PR DESCRIPTION
Previously the public RPC url was used. This worked before rinkeby support was cut from alchemy/infura. Now for Rinkeby Testnet, use the environment variable for the RPC URL.