### PR TITLE
Symbol > name

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -193,7 +193,7 @@ export function getDisplay(token: GraphToken): string {
 // Always return a non-undefined token display
 export function getFullTokenDisplay(token: Token, chainId: ChainId): string {
   if (isTokenWETH(token.address, chainId)) return `ETH`
-  return token?.name || token?.symbol || token?.address || '-'
+  return token?.symbol || token?.name || token?.address || '-'
 }
 
 export function isTokenWETH(tokenAddress?: string, chainId?: ChainId): boolean {


### PR DESCRIPTION
Symbol for the token should be listed instead of the full token name.

Switched the token.symbol and token.name in the getFullTokenDisplay() function so that unless the token.symbol returns null, the token.symbol will be returned over the token.name.

<img width="845" alt="image" src="https://user-images.githubusercontent.com/99197390/203572110-5945ea6d-2fa2-4d3a-b967-1d0dcf9a1d38.png">

- [x] Cursory code review
- [x] Cleaned unneeded code (e.g. console.logs)
- [x] Checked that the getFullTokenDisplay() function is not being used elsewhere such that the token.name must be returned before the token.symbol
