### PR TITLE
set errors for max price

### DIFF
--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -229,13 +229,13 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
 
   const priceInfo = React.useMemo(
     () =>
-      errorPrice || numericalPrice > 1
+      errorPrice || numericalPrice > 1 || numericalPrice <= graphInfo?.minimumBondPrice
         ? {
             text: errorPrice,
             type: InfoType.error,
           }
         : null,
-    [errorPrice, numericalPrice],
+    [errorPrice, numericalPrice, graphInfo],
   )
 
   const disablePlaceOrder =
@@ -248,7 +248,8 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
       showTokenConfirm ||
       sellAmount === '' ||
       price === '' ||
-      numericalPrice > 1) &&
+      numericalPrice > 1 ||
+      numericalPrice <= graphInfo?.minimumBondPrice) &&
     true
 
   const auctioningTokenAddress = auctioningToken && auctioningToken?.address

--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -229,7 +229,7 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
 
   const priceInfo = React.useMemo(
     () =>
-      errorPrice || numericalPrice >= 1
+      errorPrice || numericalPrice > 1
         ? {
             text: errorPrice,
             type: InfoType.error,
@@ -248,7 +248,7 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
       showTokenConfirm ||
       sellAmount === '' ||
       price === '' ||
-      numericalPrice >= 1) &&
+      numericalPrice > 1) &&
     true
 
   const auctioningTokenAddress = auctioningToken && auctioningToken?.address

--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -214,6 +214,8 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
   )
   const signatureAvailable = React.useMemo(() => signature && signature.length > 10, [signature])
 
+  const numericalPrice = Number(price)
+
   const amountInfo = React.useMemo(
     () =>
       errorAmount
@@ -227,13 +229,13 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
 
   const priceInfo = React.useMemo(
     () =>
-      errorPrice
+      errorPrice || numericalPrice >= 1
         ? {
             text: errorPrice,
             type: InfoType.error,
           }
         : null,
-    [errorPrice],
+    [errorPrice, numericalPrice],
   )
 
   const disablePlaceOrder =
@@ -245,7 +247,8 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
       showConfirm ||
       showTokenConfirm ||
       sellAmount === '' ||
-      price === '') &&
+      price === '' ||
+      numericalPrice >= 1) &&
     true
 
   const auctioningTokenAddress = auctioningToken && auctioningToken?.address

--- a/src/components/form/PriceInputPanel/index.tsx
+++ b/src/components/form/PriceInputPanel/index.tsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { BigNumber } from '@ethersproject/bignumber'
-import { Fraction } from '@josojo/honeyswap-sdk'
-
 import { useAuction } from '../../../hooks/useAuction'
 import { TokenPill } from '../../bond/BondAction'
 import {
@@ -18,7 +15,6 @@ import {
 } from '../../pureStyledComponents/FieldRow'
 
 import Tooltip from '@/components/common/Tooltip'
-import { isGoerli } from '@/connectors'
 import { DerivedAuctionInfo } from '@/state/orderPlacement/hooks'
 
 export const FieldRowLabelStyled = styled(FieldRowLabel)`
@@ -53,6 +49,9 @@ const PriceInputPanel = (props: Props) => {
   } = props
   const { data: graphInfo } = useAuction(auctionId)
   const error = info?.type === InfoType.error
+
+  const bondPriceNumber = Number(graphInfo.minimumBondPrice)
+  const minBondPrice = bondPriceNumber + 0.00001
 
   return (
     <>
@@ -95,21 +94,7 @@ const PriceInputPanel = (props: Props) => {
             {account && (
               <button
                 className="btn-xs btn !border-[#2A2B2C] px-3 text-xs font-normal normal-case !text-[#E0E0E0]"
-                onClick={() =>
-                  onUserPriceInput(
-                    `${derivedAuctionInfo?.initialPrice
-                      .add(
-                        new Fraction(
-                          BigNumber.from(1).toString(),
-                          BigNumber.from(10)
-                            .pow(derivedAuctionInfo?.biddingToken.decimals)
-                            .toString(),
-                        ),
-                      )
-                      .toSignificant(derivedAuctionInfo?.biddingToken.decimals)}`,
-                  )
-                }
-                style={{ visibility: isGoerli ? 'hidden' : 'visible' }}
+                onClick={() => onUserPriceInput(`${minBondPrice}`)}
               >
                 Min price
               </button>


### PR DESCRIPTION
Added an error state for if a user enters the price per bond at greater than $1. 

<img width="784" alt="image" src="https://user-images.githubusercontent.com/99197390/204805109-1208487e-4e9e-4eef-a3c6-5ab077205040.png">

<img width="756" alt="image" src="https://user-images.githubusercontent.com/99197390/204805727-0b73ca35-a68f-46e1-a97b-3a19842e0c60.png">


- [x] Cursory check of code to make sure changes do not impact anything else
- [x] Cleaned code (e.g. removed console.logs, etc.)