### PR TITLE
fix negative ytm

### DIFF
--- a/src/components/form/InterestRateInputPanel/index.tsx
+++ b/src/components/form/InterestRateInputPanel/index.tsx
@@ -53,7 +53,8 @@ export const calculateInterestRate = ({
   const years = Math.abs(startingDate.diff(maturityDate * 1000, 'year', true))
   let interestRate = (1 / nPrice) ** (1 / years) - 1
 
-  interestRate = isNaN(interestRate) || interestRate === Infinity ? 0 : interestRate
+  interestRate =
+    isNaN(interestRate) || interestRate === Infinity || interestRate < 0 ? 0 : interestRate
 
   if (display) {
     return `${round(interestRate * 100, 1).toLocaleString()}%`


### PR DESCRIPTION
On the offering page, if the bond's parameters were input incorrectly, a negative YTM would be displayed. Added logic such that if the interest rate was below 0, it would display 0% YTM.

https://www.loom.com/share/af11176b112f4dc087f2308a121d1d7e

- [x] cursory code review
- [x] removed unnecessary code/comments