### PR TITLE
fix large max ytm

### DIFF
--- a/src/components/auction/AuctionDetails/index.tsx
+++ b/src/components/auction/AuctionDetails/index.tsx
@@ -59,7 +59,7 @@ const AuctionDetails = (props: Props) => {
   const { data: auction } = useAuction(auctionIdentifier?.auctionId)
   let { orderbookPrice: auctionCurrentPrice } = useOrderbookState()
 
-  if (auctionCurrentPrice == 0) {
+  if (auctionCurrentPrice == 0 || auctionCurrentPrice > 1) {
     // use the price from the subgraph if not found on API
     auctionCurrentPrice = Number(auction.minimumBondPrice)
   }
@@ -129,6 +129,8 @@ const AuctionDetails = (props: Props) => {
       startDate: auction.end,
     }) as string
   }
+
+  console.log({ currentBondYTM, auctionCurrentPrice })
 
   const currentBondPrice = {
     fullNumberHint: auctionCurrentPrice.toLocaleString(),

--- a/src/components/form/InterestRateInputPanel/index.tsx
+++ b/src/components/form/InterestRateInputPanel/index.tsx
@@ -56,6 +56,10 @@ export const calculateInterestRate = ({
   interestRate =
     isNaN(interestRate) || interestRate === Infinity || interestRate < 0 ? 0 : interestRate
 
+  if (years < 0.002) {
+    return '-'
+  }
+
   if (display) {
     return `${round(interestRate * 100, 1).toLocaleString()}%`
   }


### PR DESCRIPTION
If the bond is set to mature within 24 hours, the interest rate algorithm returns an extremely large number. Borrowers will not be issuing such quickly maturing bonds, but for testnet, added logic to return '-' if bond matures within 24 hours.

<img width="846" alt="image" src="https://user-images.githubusercontent.com/99197390/205132527-4284674e-ee7e-492f-ac40-f211dc39dc95.png">
