### PR TITLE
add shapeshift image

### DIFF
--- a/src/components/ProductCreate/SelectableTokens.tsx
+++ b/src/components/ProductCreate/SelectableTokens.tsx
@@ -36,7 +36,7 @@ export const TESTNET_TOKEN_MAP: { [key: string]: string } = {
   ['0x1ee2926BDd6c0A34207BAEb7B8fAa12cdE0BC315'.toLowerCase()]:
     '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
   // FOX goerli
-  ['0xB514a1237860308db88758D26Bc9B065BC310748'.toLowerCase()]:
+  ['0x11f1f978f7944579bb3791b765176de3e68bffc6'.toLowerCase()]:
     '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
   // USDC goerli
   ['0x5a2D26D95b07C28d735ff76406bd82fE64222Dc1'.toLowerCase()]:

--- a/src/components/ProductCreate/SelectableTokens.tsx
+++ b/src/components/ProductCreate/SelectableTokens.tsx
@@ -36,7 +36,7 @@ export const TESTNET_TOKEN_MAP: { [key: string]: string } = {
   ['0x1ee2926BDd6c0A34207BAEb7B8fAa12cdE0BC315'.toLowerCase()]:
     '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
   // FOX goerli
-  ['0x11f1f978f7944579bb3791b765176de3e68bffc6'.toLowerCase()]:
+  ['0xB514a1237860308db88758D26Bc9B065BC310748'.toLowerCase()]:
     '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
   // USDC goerli
   ['0x5a2D26D95b07C28d735ff76406bd82fE64222Dc1'.toLowerCase()]:

--- a/src/components/token/TokenLogo/index.tsx
+++ b/src/components/token/TokenLogo/index.tsx
@@ -56,7 +56,7 @@ const TokenLogo: React.FC<TokenLogoProps> = (props) => {
 
   // Example used in dev
 
-  const lowerTokenAddress = tokenAddress.toLocaleLowerCase()
+  const lowerTokenAddress = tokenAddress.toLowerCase()
   let forceSvg = false
   if (DEV_bondImage.includes(tokenAddress)) forceSvg = true
 

--- a/src/components/token/TokenLogo/index.tsx
+++ b/src/components/token/TokenLogo/index.tsx
@@ -55,20 +55,22 @@ const TokenLogo: React.FC<TokenLogoProps> = (props) => {
   const sizeToUse = square && size === '24px' ? '30px' : size
 
   // Example used in dev
+
+  const lowerTokenAddress = tokenAddress.toLocaleLowerCase()
   let forceSvg = false
   if (DEV_bondImage.includes(tokenAddress)) forceSvg = true
 
   let chosenImage = false
-  if (tokenAddress in DEV_tokens) chosenImage = true
+  if (lowerTokenAddress in DEV_tokens) chosenImage = true
 
   const UnTok = !imageURL && <UnregisteredToken size={sizeToUse} token={token} {...restProps} />
   const ImageToken = (
     <Wrapper className="tokenLogo" size={sizeToUse} {...restProps}>
-      {chosenImage && <Image alt="token image" src={DEV_tokens[tokenAddress]?.image} />}
+      {chosenImage && <Image alt="token image" src={DEV_tokens[lowerTokenAddress]?.image} />}
       {forceSvg && (
         <UnicornSvg height={sizeToUse} style={{ borderRadius: '100%' }} width={sizeToUse} />
       )}
-      {!forceSvg && UnTok}
+      {!chosenImage && !forceSvg && UnTok}
       {!chosenImage && imageURL && <Image alt="token image" src={imageURL} />}
     </Wrapper>
   )

--- a/src/components/token/TokenLogo/index.tsx
+++ b/src/components/token/TokenLogo/index.tsx
@@ -6,7 +6,7 @@ import { useTokenListState } from '../../../state/tokenList/hooks'
 import { UnregisteredToken } from '../UnregisteredToken'
 
 import { getMappedToken } from '@/components/ProductCreate/SelectableTokens'
-import { DEV_bondImage } from '@/state/tokenList/reducer'
+import { DEV_bondImage, DEV_tokens } from '@/state/tokenList/reducer'
 
 const Wrapper = styled.div<{ size: string }>`
   background-color: #e0e0e0;
@@ -56,16 +56,20 @@ const TokenLogo: React.FC<TokenLogoProps> = (props) => {
 
   // Example used in dev
   let forceSvg = false
-  if (DEV_bondImage.includes(address)) forceSvg = true
+  if (DEV_bondImage.includes(tokenAddress)) forceSvg = true
+
+  let chosenImage = false
+  if (tokenAddress in DEV_tokens) chosenImage = true
 
   const UnTok = !imageURL && <UnregisteredToken size={sizeToUse} token={token} {...restProps} />
   const ImageToken = (
     <Wrapper className="tokenLogo" size={sizeToUse} {...restProps}>
+      {chosenImage && <Image alt="token image" src={DEV_tokens[tokenAddress]?.image} />}
       {forceSvg && (
         <UnicornSvg height={sizeToUse} style={{ borderRadius: '100%' }} width={sizeToUse} />
       )}
       {!forceSvg && UnTok}
-      {imageURL && <Image alt="token image" src={imageURL} />}
+      {!chosenImage && imageURL && <Image alt="token image" src={imageURL} />}
     </Wrapper>
   )
 

--- a/src/state/tokenList/reducer.ts
+++ b/src/state/tokenList/reducer.ts
@@ -69,6 +69,7 @@ export const DEV_bondImage = ['0xf16aaab318b61a0820a95207b54b7598b1eadc0c']
 export default createReducer<TokenListState>(initialState, (builder) =>
   builder.addCase(loadTokenListFromAPI, (state: TokenListState, { payload: { tokenList } }) => {
     const tokens = tokenList ?? {}
+
     return {
       ...state,
       tokens,

--- a/src/state/tokenList/reducer.ts
+++ b/src/state/tokenList/reducer.ts
@@ -69,7 +69,6 @@ export const DEV_bondImage = ['0xf16aaab318b61a0820a95207b54b7598b1eadc0c']
 export default createReducer<TokenListState>(initialState, (builder) =>
   builder.addCase(loadTokenListFromAPI, (state: TokenListState, { payload: { tokenList } }) => {
     const tokens = tokenList ?? {}
-    // DEV_tokens.forEach(([token, image]) => (tokens[token] = image))
     return {
       ...state,
       tokens,

--- a/src/state/tokenList/reducer.ts
+++ b/src/state/tokenList/reducer.ts
@@ -10,53 +10,58 @@ const initialState: TokenListState = {
   tokens: {},
 }
 
-export const DEV_tokens = [
-  // Ribbon Token
-  ['0xac554b8fb63ac7a46819701953a7413290c81448', 'https://etherscan.io/token/images/ribbon_32.png'],
-
-  // Ribbon Bond Development Test
-  [
-    '0x3c585f028e0f8d8fa18d2c7dbe6fd40fcd6ea2a5',
-    'https://user-images.githubusercontent.com/44010262/170816957-67584771-3ba9-48be-8ddd-eaef9efe9e04.png',
-  ],
-  // Ribbon Bond Rinkeby 1
-  [
-    '0xfbdeec30e1c93463f6c4dcbda175613aee122016',
-    'https://user-images.githubusercontent.com/44010262/170816957-67584771-3ba9-48be-8ddd-eaef9efe9e04.png',
-  ],
-
-  // Ribbon Bond Rinkeby 2
-  [
-    '0xdd14fba06df518451b1defb0527e8f9b1174b639',
-    'https://user-images.githubusercontent.com/44010262/170816957-67584771-3ba9-48be-8ddd-eaef9efe9e04.png',
-  ],
-  // Ribbon Bond Mainnet
-  [
-    '0xe34c023c0ea9899a8f8e9381437a604908e8b719',
-    'https://user-images.githubusercontent.com/44010262/170816957-67584771-3ba9-48be-8ddd-eaef9efe9e04.png',
-  ],
-
-  // Porter Bond Rinkeby
-  [
-    '0x708ef78a8aab8df64b80c5759a193a120027e2f0',
-    'https://raw.githubusercontent.com/porter-finance/docs/main/.gitbook/assets/porter_bond_60x60.png',
-  ],
-  // Porter Bond Mainnet
-  [
-    '0x9befc0322eef53531f3357b88333212c7ea8abe7',
-    'https://raw.githubusercontent.com/porter-finance/docs/main/.gitbook/assets/porter_bond_60x60.png',
-  ],
-  // USDC
-  [
-    '0x3384bfbfaebb59e281493edf8d6325a4bc1e6ba9',
-    'https://etherscan.io/token/images/centre-usdc_28.png',
-  ],
-  // USDC
-  [
-    '0x02debf352c81339a92ba137489a72885c6a12376',
-    'https://etherscan.io/token/images/centre-usdc_28.png',
-  ],
-]
+export const DEV_tokens: { [key: string]: { [key: string]: string } } = {
+  //RBN Token
+  '0xac554b8fb63ac7a46819701953a7413290c81448': {
+    image: 'https://etherscan.io/token/images/ribbon_32.png',
+  },
+  //RBN Bond Dev Test
+  '0x3c585f028e0f8d8fa18d2c7dbe6fd40fcd6ea2a5': {
+    image:
+      'https://user-images.githubusercontent.com/44010262/170816957-67584771-3ba9-48be-8ddd-eaef9efe9e04.png',
+  },
+  //RBN Bond Rinkeby 1
+  '0xfbdeec30e1c93463f6c4dcbda175613aee122016': {
+    image:
+      'https://user-images.githubusercontent.com/44010262/170816957-67584771-3ba9-48be-8ddd-eaef9efe9e04.png',
+  },
+  //RBN Bond Rinkeby 2
+  '0xdd14fba06df518451b1defb0527e8f9b1174b639': {
+    image:
+      'https://user-images.githubusercontent.com/44010262/170816957-67584771-3ba9-48be-8ddd-eaef9efe9e04.png',
+  },
+  //RBN Bond Mainnet
+  '0xe34c023c0ea9899a8f8e9381437a604908e8b719': {
+    image:
+      'https://user-images.githubusercontent.com/44010262/170816957-67584771-3ba9-48be-8ddd-eaef9efe9e04.png',
+  },
+  '0x708ef78a8aab8df64b80c5759a193a120027e2f0': {
+    image:
+      'https://raw.githubusercontent.com/porter-finance/docs/main/.gitbook/assets/porter_bond_60x60.png',
+  },
+  '0x9befc0322eef53531f3357b88333212c7ea8abe7': {
+    image:
+      'https://raw.githubusercontent.com/porter-finance/docs/main/.gitbook/assets/porter_bond_60x60.png',
+  },
+  //USDC
+  '0x1860cbca2b99B6cEE49e60d37888104ADD667dfF': {
+    image: 'https://etherscan.io/token/images/centre-usdc_28.png',
+  },
+  //USDC
+  '0x1ee2926BDd6c0A34207BAEb7B8fAa12cdE0BC315': {
+    image: 'https://etherscan.io/token/images/centre-usdc_28.png',
+  },
+  //FOX
+  '0x11f1f978f7944579bb3791b765176de3e68bffc6': {
+    image:
+      'https://assets.website-files.com/5cec55545d0f47cfe2a39a8e/61895a7ef8500fada381641f_FOX_token.svg',
+  },
+  //FOX
+  '0xb514a1237860308db88758d26bc9b065bc310748': {
+    image:
+      'https://assets.website-files.com/5cec55545d0f47cfe2a39a8e/61895a7ef8500fada381641f_FOX_token.svg',
+  },
+}
 
 // Shows unicorn simple bond svg for these
 export const DEV_bondImage = ['0xf16aaab318b61a0820a95207b54b7598b1eadc0c']
@@ -64,9 +69,7 @@ export const DEV_bondImage = ['0xf16aaab318b61a0820a95207b54b7598b1eadc0c']
 export default createReducer<TokenListState>(initialState, (builder) =>
   builder.addCase(loadTokenListFromAPI, (state: TokenListState, { payload: { tokenList } }) => {
     const tokens = tokenList ?? {}
-
-    DEV_tokens.forEach(([token, image]) => (tokens[token] = image))
-
+    // DEV_tokens.forEach(([token, image]) => (tokens[token] = image))
     return {
       ...state,
       tokens,


### PR DESCRIPTION
Added the shapeshift image to dynamically render as the bond image. For future bond issuances, devs can just add the bond contract and token address to the DEV_tokens object keyed to the image link.

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/99197390/205681733-15c97728-f586-4eb9-9d50-98369d9c8d8b.png">

- [x] cursory code review
- [x] cleaned code