### PR TITLE
Display Promissory Note

### DIFF
--- a/src/components/CreditEnhancers/index.tsx
+++ b/src/components/CreditEnhancers/index.tsx
@@ -11,7 +11,7 @@ export const CreditEnhancers = () => {
           icon: <AuctionCreateIcon />,
           url: '/credit-enhancers/promissory-note',
           title: 'Promissory Note',
-          learn: 'https://docs.arbor.finance/issuers/credit-enhancers',
+          learn: 'https://docs.arbor.finance/borrowers/credit-enhancers',
           description:
             'Enhance credit by adding a signed promise of intent to pay the bond in full.',
         },

--- a/src/components/CreditEnhancers/index.tsx
+++ b/src/components/CreditEnhancers/index.tsx
@@ -11,9 +11,9 @@ export const CreditEnhancers = () => {
           icon: <AuctionCreateIcon />,
           url: '/credit-enhancers/promissory-note',
           title: 'Promissory Note',
-          learn: 'https://docs.arbor.finance/borrowers/credit-enhancers',
+          learn: 'https://docs.arbor.finance/participants/borrowers/credit-enhancers',
           description:
-            'Enhance credit by adding a signed promise of intent to pay the bond in full.',
+            'Enhance credit by adding a signed promise of intent to repay the bond in full.',
         },
       ]}
     />

--- a/src/components/CreditEnhancers/promissory/SignatureRequest.tsx
+++ b/src/components/CreditEnhancers/promissory/SignatureRequest.tsx
@@ -6,25 +6,26 @@ export const ARBOR_PROMISSORY_NOTE_DOMAIN = ({ chainId }: { chainId: number }) =
   version: '1.0.0',
 })
 
-const ARBOR_PROMISSORY_NOTE_STRUCT = [
-  { type: 'address', name: 'bond' },
-  { type: 'string', name: 'content' },
-]
-
-export const arborTypes = {
-  PromissoryNote: ARBOR_PROMISSORY_NOTE_STRUCT,
+export const ARBOR_PROMISSORY_NOTE_TYPES = {
+  PromissoryNote: [
+    { type: 'address', name: 'bond' },
+    { type: 'string', name: 'content' },
+  ],
 }
 
+export const ARBOR_PROMISSORY_NOTE_VALUE = (bondAddress: string) => ({
+  bond: bondAddress,
+  content:
+    'This signature represents a promise to unconditionally pay the bond by the maturity date.',
+})
+
 export const signPromissoryNote = async ({ bondToSign, chainId, signer }) => {
-  const value = {
-    bond: bondToSign?.id,
-    content:
-      'This signature represents a promise to unconditionally pay the bond by the maturity date.',
-  }
+  if (!bondToSign?.id) return
+
   const signedTypedData = await signer._signTypedData(
     ARBOR_PROMISSORY_NOTE_DOMAIN({ chainId }),
-    arborTypes,
-    value,
+    ARBOR_PROMISSORY_NOTE_TYPES,
+    ARBOR_PROMISSORY_NOTE_VALUE(bondToSign.id),
   )
 
   // Gnosis Safe
@@ -39,6 +40,11 @@ export const signPromissoryNote = async ({ bondToSign, chainId, signer }) => {
   }
   console.log(signature)
   console.log(
-    verifyTypedData(ARBOR_PROMISSORY_NOTE_DOMAIN({ chainId }), arborTypes, value, signature),
+    verifyTypedData(
+      ARBOR_PROMISSORY_NOTE_DOMAIN({ chainId }),
+      ARBOR_PROMISSORY_NOTE_TYPES,
+      ARBOR_PROMISSORY_NOTE_VALUE(bondToSign.id),
+      signature,
+    ),
   )
 }

--- a/src/components/CreditEnhancers/promissory/SignatureRequest.tsx
+++ b/src/components/CreditEnhancers/promissory/SignatureRequest.tsx
@@ -1,4 +1,4 @@
-import { splitSignature, verifyTypedData } from 'ethers/lib/utils'
+import { _TypedDataEncoder, splitSignature, verifyTypedData } from 'ethers/lib/utils'
 import {} from '@rainbow-me/rainbowkit'
 export const ARBOR_PROMISSORY_NOTE_DOMAIN = ({ chainId }: { chainId: number }) => ({
   chainId,
@@ -16,8 +16,22 @@ export const ARBOR_PROMISSORY_NOTE_TYPES = {
 export const ARBOR_PROMISSORY_NOTE_VALUE = (bondAddress: string) => ({
   bond: bondAddress,
   content:
-    'This signature represents a promise to unconditionally pay the bond by the maturity date.',
+    'This signature represents a promise to unconditionally repay the bond in full by the maturity date.',
 })
+
+export const calculatedMessageHash = ({ address, chainId }: { chainId: number; address: string }) =>
+  _TypedDataEncoder.hash(
+    ARBOR_PROMISSORY_NOTE_DOMAIN({ chainId }),
+    ARBOR_PROMISSORY_NOTE_TYPES,
+    ARBOR_PROMISSORY_NOTE_VALUE(address),
+  )
+
+export const getPayload = ({ address, chainId }: { chainId: number; address: string }) =>
+  _TypedDataEncoder.getPayload(
+    ARBOR_PROMISSORY_NOTE_DOMAIN({ chainId }),
+    ARBOR_PROMISSORY_NOTE_TYPES,
+    ARBOR_PROMISSORY_NOTE_VALUE(address),
+  )
 
 export const signPromissoryNote = async ({ bondToSign, chainId, signer }) => {
   if (!bondToSign?.id) return

--- a/src/components/CreditEnhancers/promissory/StepOne.tsx
+++ b/src/components/CreditEnhancers/promissory/StepOne.tsx
@@ -77,7 +77,8 @@ export const StepOne = () => {
 
           {bondToAuction && (
             <span className="card-title border border-[#333333] p-4 text-[#9F9F9F]">
-              {`This signature represents a promise to unconditionally pay the bond by the maturity date.`}
+              This signature represents a promise to unconditionally repay the bond in full by the
+              maturity date.
             </span>
           )}
         </>

--- a/src/components/ProductCreate/CreatePanel.tsx
+++ b/src/components/ProductCreate/CreatePanel.tsx
@@ -32,7 +32,7 @@ export const CreatePanel = ({ panels }: CreatePanelProps) => {
               <div className="text-3xl font-medium text-white">{panel.title}</div>
               <p className="text-[#a1a1a1]">{panel.description}</p>
               <a
-                className="btn-sm btn mt-4 flex self-start !border-[#2A2B2C] bg-[#181A1C] !text-2sm font-normal normal-case text-white"
+                className="btn btn-sm mt-4 flex self-start !border-[#2A2B2C] bg-[#181A1C] !text-2sm font-normal normal-case text-white"
                 href={panel.learn}
                 onClick={(e) => {
                   e.stopPropagation()

--- a/src/components/PromissoryNoteModal.tsx
+++ b/src/components/PromissoryNoteModal.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+
+import MyModal from './modals/common/Modal'
+
+const PromissoryNoteModal = ({
+  close,
+  content,
+  isOpen,
+  issuer,
+  promissoryLink,
+}: {
+  close: () => void
+  content: string
+  isOpen: boolean
+  issuer: string
+  promissoryLink: string
+}) => {
+  return (
+    <MyModal blockBackdropDismiss hideCloseIcon isOpen={isOpen} onDismiss={close}>
+      <div className="mt-2 space-y-6 text-center">
+        <h1 className="text-xl font-medium text-[#E0E0E0]">Signed Promissory Note</h1>
+        <div className="space-y-4 text-left text-[#D6D6D6]">
+          <p>
+            <pre className="-ml-2 text-sm">{issuer}</pre>
+          </p>
+          <p>
+            Has{' '}
+            <a
+              className="text-[#6CADFB] hover:underline"
+              href={promissoryLink}
+              rel="noreferrer"
+              target="_blank"
+            >
+              Signed
+            </a>{' '}
+            a promissory note with the following contents.
+          </p>
+          <p>
+            <pre className="max-h-64 max-w-6xl overflow-auto">{content}</pre>
+          </p>
+          <p>
+            Learn more about our credit enhancers{' '}
+            <a
+              className="text-[#6CADFB] hover:underline"
+              href="https://docs.arbor.finance/participants/borrowers/credit-enhancers"
+              rel="noreferrer"
+              target="_blank"
+            >
+              here
+            </a>
+            .
+          </p>
+        </div>
+
+        <div className="space-x-4">
+          <button
+            className="btn btn-sm h-[41px] w-[170px] bg-[#1C701C] font-normal normal-case text-white hover:bg-[#1C701C]/80"
+            onClick={close}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </MyModal>
+  )
+}
+
+export default PromissoryNoteModal

--- a/src/pages/BondDetail/Pay.tsx
+++ b/src/pages/BondDetail/Pay.tsx
@@ -120,7 +120,7 @@ export const Pay = ({
       <SummaryItem
         border={false}
         text={`${Number(amountOwed).toLocaleString()} USDC`}
-        tip="Outstanding number of payment tokens required to fully pay the Bond."
+        tip="Outstanding number of payment tokens required to fully repay the Bond."
         title="Amount owed"
       />
       <SummaryItem


### PR DESCRIPTION
On the Issuer information display that they signed the promissory note if they did.

To show up, we need to add the `promissoryMessageHash` and `promissoryLink`. The hash and link are found from the issuers multisig sign transaction.

<img width="882" alt="CleanShot 2022-12-07 at 13 41 22@2x" src="https://user-images.githubusercontent.com/7458951/206268146-a9049f7d-6bfa-488e-80fd-e123979fa219.png">
<img width="886" alt="CleanShot 2022-12-07 at 13 41 34@2x" src="https://user-images.githubusercontent.com/7458951/206268183-aae8137c-812e-4a73-a8b0-a4eee5b30c8f.png">

The top "signed" links to the etherscan tx.
The bottom "here" links to our credit enhancers page https://docs.arbor.finance/participants/borrowers/credit-enhancers