### PR TITLE
fix minBidSize error

### DIFF
--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -172,7 +172,7 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
   const minBidSize = graphInfo?.minimumBidSize / 10 ** 6
 
   useEffect(() => {
-    if (price !== '' && Number(sellAmount) * Number(price) < minBidSize) {
+    if (price !== '' && Number(sellAmount) < minBidSize) {
       setError(true)
       setErrorText(
         `The amount of USDC you pay must exceed the minimum bid size of ${minBidSize} USDC.`,


### PR DESCRIPTION
<img width="337" alt="image" src="https://user-images.githubusercontent.com/99197390/206785380-163f214e-f101-426f-a802-50461e82b22b.png">

Fixed error such that it errors if the minimum bid size (i.e. amount of USDC paid) is less than the required amount.