### PR TITLE
fix orders table scroll

### DIFF
--- a/src/components/auction/OrderbookTable/index.tsx
+++ b/src/components/auction/OrderbookTable/index.tsx
@@ -118,7 +118,10 @@ export const TableDesign = ({
   )
 
   return (
-    <div className="min-h-[385px]" {...restProps}>
+    <div
+      className="min-h-[385px] overflow-auto scrollbar-thin scrollbar-track-zinc-800 scrollbar-thumb-zinc-700"
+      {...restProps}
+    >
       <table className="table h-full w-full" {...getTableProps()}>
         <thead className="sticky top-0 z-[1]">
           {headerGroups.map((headerGroup, i) => (
@@ -228,14 +231,14 @@ export const TableDesign = ({
         </tbody>
       </table>
       {!hidePagination && pageOptions.length > 0 && (
-        <div className="absolute right-6 bottom-7 flex items-center justify-end space-x-2 !border-none text-[#696969]">
-          <button className="btn btn-xs" disabled={!canPreviousPage} onClick={previousPage}>
+        <div className="absolute right-6 bottom-1 flex items-center justify-end space-x-2 !border-none text-[#696969]">
+          <button className="btn-xs btn" disabled={!canPreviousPage} onClick={previousPage}>
             <DoubleArrowLeftIcon />
           </button>
           <span className="text-xs text-[#696969]">
             Page {pageIndex + 1} of {pageOptions.length}
           </span>
-          <button className="btn btn-xs" disabled={!canNextPage} onClick={nextPage}>
+          <button className="btn-xs btn" disabled={!canNextPage} onClick={nextPage}>
             <DoubleArrowRightIcon />
           </button>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .table th:first-child {
+    position: relative;
+  }
+}
+
 @layer utilities {
   .text-gradient {
     background-clip: text;


### PR DESCRIPTION
Fixed the orderbook table so that it scrolls when the screen is smaller than the contents.

<img width="608" alt="image" src="https://user-images.githubusercontent.com/99197390/206875268-9df9ba91-78fc-4761-9e6d-c0c936519084.png">

- [x] Code review to make sure nothing broken with changes
- [x] Cleaned code