### PR TITLE
fixed offering number display

### DIFF
--- a/src/components/auction/AuctionDetails/index.tsx
+++ b/src/components/auction/AuctionDetails/index.tsx
@@ -81,10 +81,10 @@ const AuctionDetails = (props: Props) => {
 
   if (auction) {
     offeringSize = {
-      fullNumberHint: Number(
+      fullNumberHint: Number(formatUnits(auction.offeringSize, auction.bond.decimals)).toString(),
+      value: `${Number(
         formatUnits(auction.offeringSize, auction.bond.decimals),
-      ).toLocaleString(),
-      value: `${abbreviation(formatUnits(auction.offeringSize, auction.bond.decimals))} bonds`,
+      ).toLocaleString()} bonds`,
     }
     totalBidVolume = {
       fullNumberHint: Number(


### PR DESCRIPTION
<img width="630" alt="image" src="https://user-images.githubusercontent.com/99197390/208140280-1d049e8d-89a4-468b-a84a-da219518e6b8.png">

Fixed number by removing the abbreviation() function and adding toLocaleString()

- Because of how it will display with larger amounts, formatted the offering amount such that bond amounts greater than 1,000,000 will be abbreviated.