### PR TITLE
Add mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,6 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png" />
     <link rel="mask-icon" href="/assets/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <!-- <meta name="apple-mobile-web-app-status-bar-style" content="black" /> -->
-    <!-- <meta name="apple-mobile-web-app-capable" content="yes" /> -->
     <meta name="msapplication-config" content="/assets/browserconfig.xml" />
     <meta name="theme-color" content="#000000" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,8 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png" />
     <link rel="mask-icon" href="/assets/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <!-- <meta name="apple-mobile-web-app-status-bar-style" content="black" /> -->
+    <!-- <meta name="apple-mobile-web-app-capable" content="yes" /> -->
     <meta name="msapplication-config" content="/assets/browserconfig.xml" />
     <meta name="theme-color" content="#000000" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/components/auction/AuctionBody/index.tsx
+++ b/src/components/auction/AuctionBody/index.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, createRef, useState } from 'react'
+import React, { RefObject, createRef, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { Transition } from '@headlessui/react'
@@ -143,6 +143,7 @@ const BondCard = ({
 
 const AuctionBody = (props: AuctionBodyProps) => {
   const { auctionIdentifier, derivedAuctionInfo, graphInfo } = props
+  const [isMobile, setIsMobile] = useState(false)
   const auctionInformationRef = createRef<HTMLHeadingElement>()
   const bondTitleRef = createRef<HTMLDivElement>()
   const issuerInformationRef = createRef<HTMLButtonElement>()
@@ -156,6 +157,12 @@ const AuctionBody = (props: AuctionBodyProps) => {
     [AuctionState.ORDER_PLACING, AuctionState.ORDER_PLACING_AND_CANCELING].includes(
       derivedAuctionInfo?.auctionState,
     )
+
+  useEffect(() => {
+    if (window.innerWidth <= 800 && window.innerHeight <= 800) {
+      setIsMobile(true)
+    }
+  }, [])
 
   return (
     <>
@@ -182,13 +189,15 @@ const AuctionBody = (props: AuctionBodyProps) => {
         }
         rightChildren={
           <>
-            <AuctionTour
-              auctionInformationRef={auctionInformationRef}
-              bondTitleRef={bondTitleRef}
-              issuerInformationRef={issuerInformationRef}
-              orderbookChartRef={orderbookChartRef}
-              orderbookSelectorRef={orderbookSelectorRef}
-            />
+            <div className={isMobile ? 'hidden' : ''}>
+              <AuctionTour
+                auctionInformationRef={auctionInformationRef}
+                bondTitleRef={bondTitleRef}
+                issuerInformationRef={issuerInformationRef}
+                orderbookChartRef={orderbookChartRef}
+                orderbookSelectorRef={orderbookSelectorRef}
+              />
+            </div>
             {settling && <AuctionSettle />}
             {placeAndCancel && (
               <>

--- a/src/components/auction/AuctionBody/index.tsx
+++ b/src/components/auction/AuctionBody/index.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, createRef, useEffect, useState } from 'react'
+import React, { RefObject, createRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { Transition } from '@headlessui/react'
@@ -143,7 +143,6 @@ const BondCard = ({
 
 const AuctionBody = (props: AuctionBodyProps) => {
   const { auctionIdentifier, derivedAuctionInfo, graphInfo } = props
-  const [isMobile, setIsMobile] = useState(false)
   const auctionInformationRef = createRef<HTMLHeadingElement>()
   const bondTitleRef = createRef<HTMLDivElement>()
   const issuerInformationRef = createRef<HTMLButtonElement>()
@@ -158,18 +157,12 @@ const AuctionBody = (props: AuctionBodyProps) => {
       derivedAuctionInfo?.auctionState,
     )
 
-  useEffect(() => {
-    if (window.innerWidth <= 800 && window.innerHeight <= 800) {
-      setIsMobile(true)
-    }
-  }, [])
-
   return (
     <>
       <TwoGridPage
         leftChildren={
           <>
-            <div className={isMobile ? 'hidden' : ''}>
+            <div className="hidden sm:inline">
               <AuctionTour
                 auctionInformationRef={auctionInformationRef}
                 bondTitleRef={bondTitleRef}

--- a/src/components/auction/AuctionBody/index.tsx
+++ b/src/components/auction/AuctionBody/index.tsx
@@ -169,6 +169,15 @@ const AuctionBody = (props: AuctionBodyProps) => {
       <TwoGridPage
         leftChildren={
           <>
+            <div className={isMobile ? 'hidden' : ''}>
+              <AuctionTour
+                auctionInformationRef={auctionInformationRef}
+                bondTitleRef={bondTitleRef}
+                issuerInformationRef={issuerInformationRef}
+                orderbookChartRef={orderbookChartRef}
+                orderbookSelectorRef={orderbookSelectorRef}
+              />
+            </div>
             <AuctionDetails
               auctionIdentifier={auctionIdentifier}
               auctionInformationRef={auctionInformationRef}
@@ -189,15 +198,6 @@ const AuctionBody = (props: AuctionBodyProps) => {
         }
         rightChildren={
           <>
-            <div className={isMobile ? 'hidden' : ''}>
-              <AuctionTour
-                auctionInformationRef={auctionInformationRef}
-                bondTitleRef={bondTitleRef}
-                issuerInformationRef={issuerInformationRef}
-                orderbookChartRef={orderbookChartRef}
-                orderbookSelectorRef={orderbookSelectorRef}
-              />
-            </div>
             {settling && <AuctionSettle />}
             {placeAndCancel && (
               <>

--- a/src/components/auction/Orderbook/index.tsx
+++ b/src/components/auction/Orderbook/index.tsx
@@ -117,7 +117,7 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
         </div>
 
         {hasError && !showOrderList && <OrderBookError error={error} />}
-        {!hasError && !showOrderList && !isMobile && (
+        {!hasError && !showOrderList && (
           <OrderBookChart baseToken={baseToken} data={processedOrderbook} quoteToken={quoteToken} />
         )}
 

--- a/src/components/auction/Orderbook/index.tsx
+++ b/src/components/auction/Orderbook/index.tsx
@@ -31,7 +31,7 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
     userOrderVolume,
   } = useOrderbookState()
 
-  const [showOrderList, setShowOrderList] = useState(isGoerli)
+  const [showOrderList, setShowOrderList] = useState(true)
   const auctionIdentifier = parseURL(useParams())
   const { data: graphData } = useAuction(auctionIdentifier.auctionId)
   const { auctionId } = auctionIdentifier
@@ -72,14 +72,16 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
           <div className="flex items-center">
             <div className="btn-group" ref={orderbookSelectorRef}>
               <button
-                className={`hidden w-[85px] sm:btn`}
+                className={`hidden sm:btn ${
+                  !showOrderList && 'btn-active'
+                } pointer-events-auto w-[85px]`}
                 disabled={isGoerli}
                 onClick={() => showOrderList && setShowOrderList(false)}
               >
                 Graph
               </button>
               <button
-                className={`hidden w-[85px] sm:btn`}
+                className={`hidden sm:btn ${showOrderList && 'btn-active'} w-[85px]`}
                 onClick={() => !showOrderList && setShowOrderList(true)}
               >
                 List

--- a/src/components/auction/Orderbook/index.tsx
+++ b/src/components/auction/Orderbook/index.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useState } from 'react'
+import React, { RefObject, useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { TokenAmount } from '@josojo/honeyswap-sdk'
@@ -32,11 +32,18 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
   } = useOrderbookState()
 
   const [showOrderList, setShowOrderList] = useState(isGoerli)
+  const [isMobile, setIsMobile] = useState(false)
   const auctionIdentifier = parseURL(useParams())
   const { data: graphData } = useAuction(auctionIdentifier.auctionId)
   const { auctionId } = auctionIdentifier
 
   const { auctioningToken: baseToken, biddingToken: quoteToken } = derivedAuctionInfo || {}
+
+  useEffect(() => {
+    if (window.innerWidth <= 800 && window.innerHeight <= 800) {
+      setIsMobile(true)
+    }
+  }, [])
 
   const processedOrderbook = React.useMemo(() => {
     const data = { bids, asks }
@@ -72,9 +79,7 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
           <div className="flex items-center">
             <div className="btn-group" ref={orderbookSelectorRef}>
               <button
-                className={`hidden sm:btn ${
-                  !showOrderList && 'btn-disabled sm:btn-active'
-                } w-[85px]`}
+                className={`hidden sm:btn ${!showOrderList && 'btn-active'} w-[85px]`}
                 disabled={isGoerli}
                 onClick={() => showOrderList && setShowOrderList(false)}
               >
@@ -91,7 +96,7 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
         </div>
 
         {hasError && !showOrderList && <OrderBookError error={error} />}
-        {!hasError && !showOrderList && (
+        {!hasError && !showOrderList && !isMobile && (
           <OrderBookChart baseToken={baseToken} data={processedOrderbook} quoteToken={quoteToken} />
         )}
 

--- a/src/components/auction/Orderbook/index.tsx
+++ b/src/components/auction/Orderbook/index.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useEffect, useState } from 'react'
+import React, { RefObject, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { TokenAmount } from '@josojo/honeyswap-sdk'
@@ -32,16 +32,9 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
   } = useOrderbookState()
 
   const [showOrderList, setShowOrderList] = useState(isGoerli)
-  const [isMobile, setIsMobile] = useState(false)
   const auctionIdentifier = parseURL(useParams())
   const { data: graphData } = useAuction(auctionIdentifier.auctionId)
   const { auctionId } = auctionIdentifier
-
-  useEffect(() => {
-    if (window.innerWidth <= 800 && window.innerHeight <= 800) {
-      setIsMobile(true)
-    }
-  }, [])
 
   const { auctioningToken: baseToken, biddingToken: quoteToken } = derivedAuctionInfo || {}
 
@@ -76,17 +69,19 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
           <h2 className="card-title" ref={orderbookChartRef}>
             Orderbook
           </h2>
-          <div className="flex items-center" title="Graph is disabled on mobile and Goerli.">
-            <div className="btn-group pointer-events-none	" ref={orderbookSelectorRef}>
+          <div className="flex items-center">
+            <div className="btn-group" ref={orderbookSelectorRef}>
               <button
-                className={`btn ${!showOrderList && 'btn-active'} pointer-events-auto w-[85px]`}
-                disabled={isGoerli || isMobile}
+                className={`hidden sm:btn ${
+                  !showOrderList && 'btn-active'
+                } pointer-events-auto w-[85px]`}
+                disabled={isGoerli}
                 onClick={() => showOrderList && setShowOrderList(false)}
               >
                 Graph
               </button>
               <button
-                className={`btn ${showOrderList && 'btn-active'} w-[85px]`}
+                className={`hidden sm:btn ${showOrderList && 'btn-active'} w-[85px]`}
                 onClick={() => !showOrderList && setShowOrderList(true)}
               >
                 List

--- a/src/components/auction/Orderbook/index.tsx
+++ b/src/components/auction/Orderbook/index.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useEffect, useState } from 'react'
+import React, { RefObject, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { TokenAmount } from '@josojo/honeyswap-sdk'
@@ -32,18 +32,11 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
   } = useOrderbookState()
 
   const [showOrderList, setShowOrderList] = useState(isGoerli)
-  const [isMobile, setIsMobile] = useState(false)
   const auctionIdentifier = parseURL(useParams())
   const { data: graphData } = useAuction(auctionIdentifier.auctionId)
   const { auctionId } = auctionIdentifier
 
   const { auctioningToken: baseToken, biddingToken: quoteToken } = derivedAuctionInfo || {}
-
-  useEffect(() => {
-    if (window.innerWidth <= 800 && window.innerHeight <= 800) {
-      setIsMobile(true)
-    }
-  }, [])
 
   const processedOrderbook = React.useMemo(() => {
     const data = { bids, asks }
@@ -78,50 +71,29 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
           </h2>
           <div className="flex items-center">
             <div className="btn-group" ref={orderbookSelectorRef}>
-              {/* {isMobile && (
-                <>
-                  <button
-                    className={`hidden w-[85px] sm:btn`}
-                    disabled={isGoerli}
-                    onClick={() => showOrderList && setShowOrderList(false)}
-                  >
-                    Graph
-                  </button>
-                  <button
-                    className={`hidden w-[85px] sm:btn`}
-                    onClick={() => !showOrderList && setShowOrderList(true)}
-                  >
-                    List
-                  </button>
-                </>
-              )}
-              {!isMobile && (
-                <> */}
               <button
-                className={`hidden sm:btn ${!showOrderList && 'btn-active'} w-[85px]`}
+                className={`hidden w-[85px] sm:btn`}
                 disabled={isGoerli}
                 onClick={() => showOrderList && setShowOrderList(false)}
               >
                 Graph
               </button>
               <button
-                className={`hidden sm:btn ${showOrderList && 'btn-active'} w-[85px]`}
+                className={`hidden w-[85px] sm:btn`}
                 onClick={() => !showOrderList && setShowOrderList(true)}
               >
                 List
               </button>
-              {/* </>
-              )} */}
             </div>
           </div>
         </div>
 
         {hasError && !showOrderList && <OrderBookError error={error} />}
-        {!hasError && !showOrderList && !isMobile && (
+        {!hasError && !showOrderList && (
           <OrderBookChart baseToken={baseToken} data={processedOrderbook} quoteToken={quoteToken} />
         )}
 
-        {showOrderList && isMobile && <OrderBookTable derivedAuctionInfo={derivedAuctionInfo} />}
+        {showOrderList && <OrderBookTable derivedAuctionInfo={derivedAuctionInfo} />}
       </div>
     </div>
   )

--- a/src/components/auction/Orderbook/index.tsx
+++ b/src/components/auction/Orderbook/index.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useState } from 'react'
+import React, { RefObject, useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { TokenAmount } from '@josojo/honeyswap-sdk'
@@ -37,11 +37,11 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
   const { data: graphData } = useAuction(auctionIdentifier.auctionId)
   const { auctionId } = auctionIdentifier
 
-  // useEffect(() => {
-  //   if (window.innerWidth <= 800 && window.innerHeight <= 600) {
-  //     setIsMobile(true)
-  //   }
-  // }, [])
+  useEffect(() => {
+    if (window.innerWidth <= 800 && window.innerHeight <= 800) {
+      setIsMobile(true)
+    }
+  }, [])
 
   const { auctioningToken: baseToken, biddingToken: quoteToken } = derivedAuctionInfo || {}
 
@@ -76,11 +76,11 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
           <h2 className="card-title" ref={orderbookChartRef}>
             Orderbook
           </h2>
-          <div className="flex items-center">
-            <div className="btn-group" ref={orderbookSelectorRef}>
+          <div className="flex items-center" title="Graph is disabled on mobile and Goerli.">
+            <div className="btn-group pointer-events-none	" ref={orderbookSelectorRef}>
               <button
-                className={`btn ${!showOrderList && 'btn-active'} w-[85px]`}
-                disabled={isGoerli}
+                className={`btn ${!showOrderList && 'btn-active'} pointer-events-auto w-[85px]`}
+                disabled={isGoerli || isMobile}
                 onClick={() => showOrderList && setShowOrderList(false)}
               >
                 Graph

--- a/src/components/auction/Orderbook/index.tsx
+++ b/src/components/auction/Orderbook/index.tsx
@@ -73,8 +73,8 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
             <div className="btn-group" ref={orderbookSelectorRef}>
               <button
                 className={`hidden sm:btn ${
-                  !showOrderList && 'btn-active'
-                } pointer-events-auto w-[85px]`}
+                  !showOrderList && 'btn-disabled sm:btn-active'
+                } w-[85px]`}
                 disabled={isGoerli}
                 onClick={() => showOrderList && setShowOrderList(false)}
               >

--- a/src/components/auction/Orderbook/index.tsx
+++ b/src/components/auction/Orderbook/index.tsx
@@ -78,19 +78,40 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
           </h2>
           <div className="flex items-center">
             <div className="btn-group" ref={orderbookSelectorRef}>
-              <button
-                className={`hidden sm:btn ${!showOrderList && 'btn-active'} w-[85px]`}
-                disabled={isGoerli}
-                onClick={() => showOrderList && setShowOrderList(false)}
-              >
-                Graph
-              </button>
-              <button
-                className={`hidden sm:btn ${showOrderList && 'btn-active'} w-[85px]`}
-                onClick={() => !showOrderList && setShowOrderList(true)}
-              >
-                List
-              </button>
+              {isMobile && (
+                <>
+                  <button
+                    className={`hidden w-[85px] sm:btn`}
+                    disabled={isGoerli}
+                    onClick={() => showOrderList && setShowOrderList(false)}
+                  >
+                    Graph
+                  </button>
+                  <button
+                    className={`hidden w-[85px] sm:btn`}
+                    onClick={() => !showOrderList && setShowOrderList(true)}
+                  >
+                    List
+                  </button>
+                </>
+              )}
+              {!isMobile && (
+                <>
+                  <button
+                    className={`hidden sm:btn ${!showOrderList && 'btn-active'} w-[85px]`}
+                    disabled={isGoerli}
+                    onClick={() => showOrderList && setShowOrderList(false)}
+                  >
+                    Graph
+                  </button>
+                  <button
+                    className={`hidden sm:btn ${showOrderList && 'btn-active'} w-[85px]`}
+                    onClick={() => !showOrderList && setShowOrderList(true)}
+                  >
+                    List
+                  </button>
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/auction/Orderbook/index.tsx
+++ b/src/components/auction/Orderbook/index.tsx
@@ -78,7 +78,7 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
           </h2>
           <div className="flex items-center">
             <div className="btn-group" ref={orderbookSelectorRef}>
-              {isMobile && (
+              {/* {isMobile && (
                 <>
                   <button
                     className={`hidden w-[85px] sm:btn`}
@@ -96,32 +96,32 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
                 </>
               )}
               {!isMobile && (
-                <>
-                  <button
-                    className={`hidden sm:btn ${!showOrderList && 'btn-active'} w-[85px]`}
-                    disabled={isGoerli}
-                    onClick={() => showOrderList && setShowOrderList(false)}
-                  >
-                    Graph
-                  </button>
-                  <button
-                    className={`hidden sm:btn ${showOrderList && 'btn-active'} w-[85px]`}
-                    onClick={() => !showOrderList && setShowOrderList(true)}
-                  >
-                    List
-                  </button>
-                </>
-              )}
+                <> */}
+              <button
+                className={`hidden sm:btn ${!showOrderList && 'btn-active'} w-[85px]`}
+                disabled={isGoerli}
+                onClick={() => showOrderList && setShowOrderList(false)}
+              >
+                Graph
+              </button>
+              <button
+                className={`hidden sm:btn ${showOrderList && 'btn-active'} w-[85px]`}
+                onClick={() => !showOrderList && setShowOrderList(true)}
+              >
+                List
+              </button>
+              {/* </>
+              )} */}
             </div>
           </div>
         </div>
 
         {hasError && !showOrderList && <OrderBookError error={error} />}
-        {!hasError && !showOrderList && (
+        {!hasError && !showOrderList && !isMobile && (
           <OrderBookChart baseToken={baseToken} data={processedOrderbook} quoteToken={quoteToken} />
         )}
 
-        {showOrderList && <OrderBookTable derivedAuctionInfo={derivedAuctionInfo} />}
+        {showOrderList && isMobile && <OrderBookTable derivedAuctionInfo={derivedAuctionInfo} />}
       </div>
     </div>
   )

--- a/src/components/auction/Orderbook/index.tsx
+++ b/src/components/auction/Orderbook/index.tsx
@@ -32,9 +32,16 @@ export const OrderBook: React.FC<OrderbookGraphProps> = (props) => {
   } = useOrderbookState()
 
   const [showOrderList, setShowOrderList] = useState(isGoerli)
+  const [isMobile, setIsMobile] = useState(false)
   const auctionIdentifier = parseURL(useParams())
   const { data: graphData } = useAuction(auctionIdentifier.auctionId)
   const { auctionId } = auctionIdentifier
+
+  // useEffect(() => {
+  //   if (window.innerWidth <= 800 && window.innerHeight <= 600) {
+  //     setIsMobile(true)
+  //   }
+  // }, [])
 
   const { auctioningToken: baseToken, biddingToken: quoteToken } = derivedAuctionInfo || {}
 

--- a/src/components/auctions/Table/index.tsx
+++ b/src/components/auctions/Table/index.tsx
@@ -5,8 +5,6 @@ import styled from 'styled-components'
 import { useGlobalFilter, useTable } from 'react-table'
 
 import { ActionButton } from '../../auction/Claimer'
-// import { Delete } from '../../icons/Delete'
-// import { Magnifier } from '../../icons/Magnifier'
 import { PageTitle } from '../../pureStyledComponents/PageTitle'
 
 import Tooltip from '@/components/common/Tooltip'
@@ -140,10 +138,6 @@ const Table = ({
 
   const sectionHead = useRef(null)
 
-  const menuToggle = () => {
-    setMenuVisible(!menuVisible)
-  }
-
   return (
     <Wrapper ref={sectionHead} {...restProps}>
       <div className="mb-10 flex flex-wrap content-center items-end py-2 md:justify-between">
@@ -151,29 +145,7 @@ const Table = ({
           <SectionTitle>{title}</SectionTitle>
           <div className="hidden flex-row items-center space-x-4 sm:flex">{legendIcons}</div>
         </div>
-        <div className="my-12 sm:mt-5">
-          {/* <TableControls>
-            <SearchWrapper>
-              <Magnifier />
-              <SearchInput
-                onChange={(e) => {
-                  setGlobalFilter(e.target.value)
-                }}
-                placeholder="Search"
-                value={state.globalFilter || ''}
-              />
-              <DeleteSearchTerm
-                aria-label="Delete Search Term"
-                disabled={!state.globalFilter}
-                onClick={() => {
-                  setGlobalFilter(undefined)
-                }}
-              >
-                <Delete />
-              </DeleteSearchTerm>
-            </SearchWrapper>
-          </TableControls> */}
-        </div>
+        <div className="my-12 sm:mt-5"></div>
       </div>
 
       <div

--- a/src/components/auctions/Table/index.tsx
+++ b/src/components/auctions/Table/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useRef, useState } from 'react'
+import React, { ReactElement, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -18,68 +18,6 @@ const SectionTitle = styled(PageTitle)`
   font-size: 42px;
   color: #e0e0e0;
   margin: 0;
-`
-
-const TableControls = styled.div`
-  @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-  }
-`
-
-const SearchWrapper = styled.div`
-  align-items: center;
-  display: flex;
-  max-width: 100%;
-  padding-left: 9px;
-  padding-right: 0;
-  width: 237px;
-  border-radius: 100px;
-  background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.5);
-`
-
-const SearchInput = styled.input`
-  border: none;
-  background: none;
-  font-style: normal;
-  font-weight: 400;
-  font-size: 12px;
-  letter-spacing: 0.06em;
-  color: #fafafa;
-  ::placeholder {
-    text-transform: uppercase;
-    color: #fafafa;
-    opacity: 0.8;
-  }
-  flex-grow: 1;
-  height: 32px;
-  margin: 0 0 0 10px;
-  outline: none;
-  overflow: hidden;
-  padding: 0;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`
-
-const DeleteSearchTerm = styled.button`
-  align-items: center;
-  background: none;
-  border: none;
-  cursor: pointer;
-  display: flex;
-  flex-shrink: none;
-  height: 100%;
-  justify-content: center;
-  margin: 0;
-  outline: none;
-  padding: 0;
-  width: 38px;
-
-  &[disabled] {
-    opacity: 0.5;
-  }
 `
 
 interface Props {
@@ -111,7 +49,6 @@ const Table = ({
   ...restProps
 }: Props) => {
   const navigate = useNavigate()
-  const [menuVisible, setMenuVisible] = useState(false)
 
   const globalFilter = React.useMemo(
     () => (rows, columns, filterValue) =>

--- a/src/components/auctions/Table/index.tsx
+++ b/src/components/auctions/Table/index.tsx
@@ -5,13 +5,11 @@ import styled from 'styled-components'
 import { useGlobalFilter, useTable } from 'react-table'
 
 import { ActionButton } from '../../auction/Claimer'
-import { Delete } from '../../icons/Delete'
-import { Magnifier } from '../../icons/Magnifier'
+// import { Delete } from '../../icons/Delete'
+// import { Magnifier } from '../../icons/Magnifier'
 import { PageTitle } from '../../pureStyledComponents/PageTitle'
 
 import Tooltip from '@/components/common/Tooltip'
-import { ButtonMenuStyled } from '@/components/layout/Header'
-import { OfferingMenu } from '@/components/navigation/OfferingMenu'
 
 const Wrapper = styled.div`
   margin-top: -30px;
@@ -151,14 +149,10 @@ const Table = ({
       <div className="mb-10 flex flex-wrap content-center items-end py-2 md:justify-between">
         <div className="flex flex-col space-y-4">
           <SectionTitle>{title}</SectionTitle>
-          <ButtonMenuStyled className={menuVisible && 'active'} onClick={menuToggle} />
-          {menuVisible && (
-            <OfferingMenu legendIcons={legendIcons} onClose={() => setMenuVisible(false)} />
-          )}
           <div className="hidden flex-row items-center space-x-4 sm:flex">{legendIcons}</div>
         </div>
-        <div className="mt-5 sm:mt-0">
-          <TableControls>
+        <div className="my-12 sm:mt-5">
+          {/* <TableControls>
             <SearchWrapper>
               <Magnifier />
               <SearchInput
@@ -178,7 +172,7 @@ const Table = ({
                 <Delete />
               </DeleteSearchTerm>
             </SearchWrapper>
-          </TableControls>
+          </TableControls> */}
         </div>
       </div>
 

--- a/src/components/auctions/Table/index.tsx
+++ b/src/components/auctions/Table/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useRef } from 'react'
+import React, { ReactElement, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -10,6 +10,8 @@ import { Magnifier } from '../../icons/Magnifier'
 import { PageTitle } from '../../pureStyledComponents/PageTitle'
 
 import Tooltip from '@/components/common/Tooltip'
+import { ButtonMenuStyled } from '@/components/layout/Header'
+import { OfferingMenu } from '@/components/navigation/OfferingMenu'
 
 const Wrapper = styled.div`
   margin-top: -30px;
@@ -113,6 +115,7 @@ const Table = ({
   ...restProps
 }: Props) => {
   const navigate = useNavigate()
+  const [menuVisible, setMenuVisible] = useState(false)
 
   const globalFilter = React.useMemo(
     () => (rows, columns, filterValue) =>
@@ -139,16 +142,22 @@ const Table = ({
 
   const sectionHead = useRef(null)
 
+  const menuToggle = () => {
+    setMenuVisible(!menuVisible)
+  }
+
   return (
     <Wrapper ref={sectionHead} {...restProps}>
-      <div className="mb-10 flex flex-wrap content-center items-end justify-center py-2 md:justify-between">
+      <div className="mb-10 flex flex-wrap content-center items-end py-2 md:justify-between">
         <div className="flex flex-col space-y-4">
           <SectionTitle>{title}</SectionTitle>
-
-          <div className="flex flex-row items-center space-x-4">{legendIcons}</div>
+          <ButtonMenuStyled className={menuVisible && 'active'} onClick={menuToggle} />
+          {menuVisible && (
+            <OfferingMenu legendIcons={legendIcons} onClose={() => setMenuVisible(false)} />
+          )}
+          <div className="hidden flex-row items-center space-x-4 sm:flex">{legendIcons}</div>
         </div>
-
-        <div>
+        <div className="mt-5 sm:mt-0">
           <TableControls>
             <SearchWrapper>
               <Magnifier />

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -32,7 +32,7 @@ export const Inner = styled(InnerContainer)`
   justify-content: space-between;
 `
 
-const ButtonMenuStyled = styled(ButtonMenu)`
+export const ButtonMenuStyled = styled(ButtonMenu)`
   display: block;
   position: relative;
   z-index: 5;
@@ -42,7 +42,7 @@ const ButtonMenuStyled = styled(ButtonMenu)`
   }
 `
 
-const Menu = styled(Mainmenu)`
+export const Menu = styled(Mainmenu)`
   display: none;
 
   @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {

--- a/src/components/navigation/OfferingMenu/index.tsx
+++ b/src/components/navigation/OfferingMenu/index.tsx
@@ -1,0 +1,77 @@
+import React, { ReactElement } from 'react'
+import { NavLink } from 'react-router-dom'
+import styled from 'styled-components'
+
+const Wrapper = styled.nav`
+  background-color: ${({ theme }) => theme.modal.overlay.backgroundColor};
+  display: block;
+  height: calc(100vh - ${({ theme }) => theme.header.height});
+  left: 0;
+  position: fixed;
+  top: ${({ theme }) => theme.header.height};
+  width: 100%;
+  z-index: 12345;
+
+  @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
+    display: none;
+  }
+`
+
+const Inner = styled.div`
+  background-color: ${({ theme }) => theme.mainBackground};
+  border-top: 1px solid ${({ theme }) => theme.border};
+`
+
+const Item = styled(NavLink)`
+  align-items: center;
+  background-color: ${({ theme }) => theme.mainBackground};
+  border-bottom: 1px solid ${({ theme }) => theme.border};
+  color: ${({ theme }) => theme.text1};
+  display: flex;
+  font-size: 17px;
+  font-weight: 400;
+  height: 44px;
+  justify-content: space-between;
+  line-height: 1.2;
+  padding: 0 14px;
+  text-decoration: none;
+  transition: all 0.1s linear;
+
+  &.active {
+    color: ${({ theme }) => theme.primary1};
+
+    .fill {
+      fill: ${({ theme }) => theme.primary1};
+    }
+  }
+
+  &.active:active,
+  &:active {
+    color: ${({ theme }) => theme.primary1};
+    opacity: 0.5;
+  }
+`
+
+interface Props {
+  onClose: () => void
+  legendIcons: ReactElement
+}
+
+export const OfferingMenu: React.FC<Props> = (props) => {
+  const { legendIcons, onClose, ...restProps } = props
+
+  const onCloseDelay = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    e.preventDefault()
+    setTimeout(() => {
+      onClose()
+    }, 100)
+  }
+
+  return (
+    <Wrapper onClick={onCloseDelay} {...restProps}>
+      <Inner>
+        <div className="">{legendIcons}</div>
+      </Inner>
+    </Wrapper>
+  )
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,6 @@ import { WagmiConfig, chain, chainId, configureChains, createClient } from 'wagm
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc'
 import { publicProvider } from 'wagmi/providers/public'
 
-// import { MobileBlocker } from './components/MobileBlocker'
 import { isGoerli, isProdGoerli } from './connectors'
 import App from './pages/App'
 import store from './state'
@@ -98,10 +97,7 @@ root.render(
             <ThemeProvider>
               <GlobalStyle />
               <BrowserRouter>
-                {/* <div className="hidden sm:block"> */}
                 <App />
-                {/* </div> */}
-                {/* <MobileBlocker /> */}
               </BrowserRouter>
             </ThemeProvider>
           </ApolloProvider>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import { WagmiConfig, chain, chainId, configureChains, createClient } from 'wagm
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc'
 import { publicProvider } from 'wagmi/providers/public'
 
-import { MobileBlocker } from './components/MobileBlocker'
+// import { MobileBlocker } from './components/MobileBlocker'
 import { isGoerli, isProdGoerli } from './connectors'
 import App from './pages/App'
 import store from './state'
@@ -98,10 +98,10 @@ root.render(
             <ThemeProvider>
               <GlobalStyle />
               <BrowserRouter>
-                <div className="hidden sm:block">
-                  <App />
-                </div>
-                <MobileBlocker />
+                {/* <div className="hidden sm:block"> */}
+                <App />
+                {/* </div> */}
+                {/* <MobileBlocker /> */}
               </BrowserRouter>
             </ThemeProvider>
           </ApolloProvider>

--- a/src/pages/Auction/index.tsx
+++ b/src/pages/Auction/index.tsx
@@ -161,7 +161,7 @@ const AuctionPage = ({ data: { auctionIdentifier, derivedAuctionInfo, graphInfo 
         {loading && <LoadingTwoGrid />}
         {!loading && (
           <>
-            <div className="flex flex-wrap content-center items-end justify-center py-2 md:justify-between">
+            <div className="-mt-10 flex flex-wrap content-center items-end justify-center py-2 md:justify-between">
               <div className="flex flex-wrap items-center space-x-6">
                 <div className="hidden md:flex">
                   <TokenLogo

--- a/src/pages/Auction/index.tsx
+++ b/src/pages/Auction/index.tsx
@@ -88,7 +88,7 @@ export const LoadingBox = ({ className = '', height }) => (
 )
 
 export const TwoGridPage = ({ leftChildren, rightChildren }) => (
-  <main className="mt-[15px] px-0 pb-8">
+  <main className="px-0 pb-8 sm:mt-[15px]">
     {/* Main 3 column grid */}
     <div className="grid grid-cols-1 items-start gap-4 pb-32 lg:grid-cols-3 lg:gap-8">
       {/* Left column */}
@@ -178,7 +178,9 @@ const AuctionPage = ({ data: { auctionIdentifier, derivedAuctionInfo, graphInfo 
                   <p className="text-2sm text-[#E0E0E0]">{graphInfo?.bond.symbol}</p>
                 </div>
               </div>
-              <AuctionButtonOutline />
+              <div className="hidden lg:flex">
+                <AuctionButtonOutline />
+              </div>
             </div>
 
             <AuctionBody

--- a/src/pages/Auction/index.tsx
+++ b/src/pages/Auction/index.tsx
@@ -161,7 +161,7 @@ const AuctionPage = ({ data: { auctionIdentifier, derivedAuctionInfo, graphInfo 
         {loading && <LoadingTwoGrid />}
         {!loading && (
           <>
-            <div className="-mt-10 flex flex-wrap content-center items-end justify-center py-2 md:justify-between">
+            <div className="-mt-10 flex flex-wrap content-center items-end justify-center py-2 sm:mt-0 md:justify-between">
               <div className="flex flex-wrap items-center space-x-6">
                 <div className="hidden md:flex">
                   <TokenLogo

--- a/src/pages/Auction/index.tsx
+++ b/src/pages/Auction/index.tsx
@@ -90,14 +90,14 @@ export const LoadingBox = ({ className = '', height }) => (
 export const TwoGridPage = ({ leftChildren, rightChildren }) => (
   <main className="px-0 pb-8 sm:mt-[15px]">
     {/* Main 3 column grid */}
-    <div className="grid grid-cols-1 items-start gap-4 pb-32 lg:grid-cols-3 lg:gap-8">
+    <div className="grid grid-cols-1 items-start gap-4 pb-2 lg:grid-cols-3 lg:gap-8">
       {/* Left column */}
       <div className="grid grid-cols-1 gap-4 lg:col-span-2">
         <section aria-labelledby="section-1-title">{leftChildren}</section>
       </div>
 
       {/* Right column */}
-      <div className="order-first grid grid-cols-1 gap-4 lg:order-last">
+      <div className="grid grid-cols-1 gap-4 lg:order-last">
         <section aria-labelledby="section-2-title">{rightChildren}</section>
       </div>
     </div>

--- a/src/pages/BondDetail/index.tsx
+++ b/src/pages/BondDetail/index.tsx
@@ -427,7 +427,7 @@ const BondDetail: React.FC = () => {
                           rel="noreferrer"
                           target="_blank"
                         >
-                          <button className="btn btn-primary btn-sm space-x-2 rounded-md bg-[#293327] !text-xxs font-normal">
+                          <button className="btn-primary btn-sm btn space-x-2 rounded-md bg-[#293327] !text-xxs font-normal">
                             <span>Issuer Information</span>
                             <span>
                               <DoubleArrowRightIcon />
@@ -453,9 +453,9 @@ const BondDetail: React.FC = () => {
                   </div>
                 </div>
               </div>
-
-              <BondGraphCard bond={bond as Bond} />
-
+              <div className="hidden sm:flex">
+                <BondGraphCard bond={bond as Bond} />
+              </div>
               <div className="card">
                 <div className="card-body">
                   <h2 className="card-title">Your position</h2>

--- a/src/pages/BondDetail/index.tsx
+++ b/src/pages/BondDetail/index.tsx
@@ -361,7 +361,7 @@ const BondDetail: React.FC = () => {
     <>
       <GlobalStyle />
       <ErrorBoundaryWithFallback>
-        <div className="flex flex-wrap content-center items-end justify-center py-2 md:justify-between">
+        <div className="-mt-10 flex flex-wrap content-center items-end justify-center py-2 md:mt-0 md:justify-between">
           <div className="flex flex-wrap items-center space-x-6">
             <div className="hidden md:flex">
               <TokenLogo
@@ -380,7 +380,9 @@ const BondDetail: React.FC = () => {
               </p>
             </div>
           </div>
-          <div>{isConvertBond ? <ConvertButtonOutline /> : <SimpleButtonOutline />}</div>
+          <div className="hidden lg:flex">
+            {isConvertBond ? <ConvertButtonOutline /> : <SimpleButtonOutline />}
+          </div>
         </div>
 
         <TwoGridPage
@@ -467,7 +469,7 @@ const BondDetail: React.FC = () => {
                   ) : null}
                   {account && positionData?.length ? (
                     <TableDesign
-                      className="min-h-full"
+                      className="min-h-full overflow-auto"
                       columns={positionColumns}
                       data={positionData}
                       hidePagination


### PR DESCRIPTION
Fixed styling so that it is order compatible.

<img width="404" alt="image" src="https://user-images.githubusercontent.com/99197390/208271441-8686f3b8-b66f-4c3a-96af-a5600d4a2fca.png">

<img width="373" alt="image" src="https://user-images.githubusercontent.com/99197390/208271445-f8dd4907-50af-4a61-8a49-0876feac3c5c.png">

<img width="401" alt="image" src="https://user-images.githubusercontent.com/99197390/208271449-f5fe7531-0065-4b8a-9ca7-9cca699801db.png">

<img width="353" alt="image" src="https://user-images.githubusercontent.com/99197390/208271489-2e947a20-e21e-4c96-a274-2f91bc8209dd.png">

<img width="374" alt="image" src="https://user-images.githubusercontent.com/99197390/208271493-1dd4d0e5-8b65-4c4a-a994-dba71b4793bf.png">

- [x] Fixed offerings table, auction, bond table, and bonds pages
- [ ] Auction and bonds pages headings spacing is bad. I tried different things with the flexboxes, but the only solution I came up with that looked good was the negative margin. Let me know if you find a better solution.
- [x] Checked impact of styling on different screen sizes
- [x] Checked that the changes don't make any breaks
- [x] Turned off graph and tour features as they aren't conducive to the mobile set-up