### PR TITLE
fix rounding on order volume

### DIFF
--- a/src/components/auction/AuctionDetails/index.tsx
+++ b/src/components/auction/AuctionDetails/index.tsx
@@ -95,7 +95,13 @@ const AuctionDetails = (props: Props) => {
         formatUnits(auction.totalBidVolume, auction.bidding.decimals),
       ).toLocaleString(),
       value: (
-        <TokenInfoWithLink auction={auction} value={auction.totalBidVolume} withLink={false} />
+        <TokenValue className="space-x-1">
+          <span>
+            {Math.round(
+              Number(formatUnits(auction.totalBidVolume, auction.bidding.decimals)),
+            ).toLocaleString()}
+          </span>
+        </TokenValue>
       ),
     }
     minimumFundingThreshold = {

--- a/src/components/auction/AuctionDetails/index.tsx
+++ b/src/components/auction/AuctionDetails/index.tsx
@@ -217,8 +217,6 @@ const AuctionDetails = (props: Props) => {
     },
   ]
 
-  console.log({ auction })
-
   return (
     <div className="card">
       <div className="card-body">


### PR DESCRIPTION
<img width="774" alt="image" src="https://user-images.githubusercontent.com/99197390/208762942-30eb6f5d-8895-4db0-99e3-cea1ca6c2d1c.png">


Added Math.round() so that the bid volume rounds to the nearest integer.

- [x] Cleaned code
- [x] Checked that this doesn't break any other components