### PR TITLE
Add token offering

### DIFF
--- a/src/components/auction/AuctionDetails/index.tsx
+++ b/src/components/auction/AuctionDetails/index.tsx
@@ -101,6 +101,7 @@ const AuctionDetails = (props: Props) => {
               Number(formatUnits(auction.totalBidVolume, auction.bidding.decimals)),
             ).toLocaleString()}
           </span>
+          <TokenLink token={auction?.bidding} withLink={false} />
         </TokenValue>
       ),
     }


### PR DESCRIPTION
Add the bidding token back to the total order volume on the auction details page.

<img width="731" alt="image" src="https://user-images.githubusercontent.com/99197390/208806396-94dc31a9-7857-40bf-810f-866faddc19be.png">
