### PR TITLE
add two column break point

### DIFF
--- a/src/pages/BondDetail/index.tsx
+++ b/src/pages/BondDetail/index.tsx
@@ -432,8 +432,8 @@ const BondDetail: React.FC = () => {
                       </>
                     )}
                     <div
-                      className={`grid grid-cols-1 gap-x-12 gap-y-8 pt-8 ${
-                        isConvertBond ? 'md:grid-cols-3' : 'md:grid-cols-4'
+                      className={`grid grid-cols-1 gap-x-12 gap-y-8 pt-8 sm:grid-cols-2 ${
+                        isConvertBond ? 'lg:grid-cols-3' : 'lg:grid-cols-4'
                       }`}
                     >
                       <BondDetails id={bond?.id} />


### PR DESCRIPTION
Added another break point so that the transition between larger and smaller screens is better. This way, the links are not all scrunched up on smaller screen sizes, but still moves to the one column on mobile. There is still a slight crunch when the screen is right between the small and xs sizes, but it is less than previously.

<img width="527" alt="image" src="https://user-images.githubusercontent.com/99197390/210149505-759fefcc-0f51-45fc-82cf-c17c6e49846f.png">
 