### PR TITLE
bond graph container  inline

### DIFF
--- a/src/pages/BondDetail/index.tsx
+++ b/src/pages/BondDetail/index.tsx
@@ -491,7 +491,7 @@ const BondDetail: React.FC = () => {
                   </div>
                 </div>
               </div>
-              <div className="hidden sm:flex">
+              <div className="hidden sm:inline">
                 <BondGraphCard bond={bond as Bond} />
               </div>
               <div className="card">


### PR DESCRIPTION
Changed container to inline

<img width="580" alt="image" src="https://user-images.githubusercontent.com/99197390/210606204-8f9cc8fa-2039-4f3c-9dc9-56362676bfc8.png">

- [x] Checked response on varying screen sizes
- [x] Cursory code review