### PR TITLE
Fix green

### DIFF
--- a/src/components/CreditEnhancers/promissory/FormSteps.tsx
+++ b/src/components/CreditEnhancers/promissory/FormSteps.tsx
@@ -76,7 +76,7 @@ export const FormSteps = ({
               <div className="space-y-4">
                 {!account && (
                   <ActionButton className="mt-4" color={color} onClick={toggleWalletModal}>
-                    Connect wallet
+                    Connect Wallet
                   </ActionButton>
                 )}
 

--- a/src/components/ProductCreate/FormSteps.tsx
+++ b/src/components/ProductCreate/FormSteps.tsx
@@ -77,7 +77,7 @@ export const FormSteps = ({
               <div className="space-y-4">
                 {!account && (
                   <ActionButton className="mt-4" color={color} onClick={toggleWalletModal}>
-                    Connect wallet
+                    Connect Wallet
                   </ActionButton>
                 )}
 

--- a/src/components/ProductCreate/selectors/CollateralTokenSelector.tsx
+++ b/src/components/ProductCreate/selectors/CollateralTokenSelector.tsx
@@ -55,7 +55,7 @@ const NoBondFound = () => {
       <div className="flex w-full justify-between">
         <ArborIcon />
         <div className="flex flex-col">
-          <span>No Bonds available to auction.</span> {!address && 'Connect wallet'}
+          <span>No Bonds available to auction.</span> {!address && 'Connect Wallet'}
         </div>
       </div>
     </div>

--- a/src/components/auction/AuctionBody/index.tsx
+++ b/src/components/auction/AuctionBody/index.tsx
@@ -95,7 +95,7 @@ const BondCard = ({
         <div className="flex items-center justify-between">
           <h2 className="card-title">Bond information</h2>
           <button
-            className="btn-primary btn-sm btn space-x-2 rounded-md bg-[#293327] !text-xxs font-normal"
+            className="btn-primary btn-sm btn space-x-2 rounded-md bg-[#1C701C] !text-xxs font-normal"
             onClick={() => navigate(`/bonds/${graphInfo?.bond.id || ''}`)}
           >
             <span>Learn more</span>

--- a/src/components/auction/AuctionDetails/index.tsx
+++ b/src/components/auction/AuctionDetails/index.tsx
@@ -165,36 +165,12 @@ const AuctionDetails = (props: Props) => {
 
   const extraDetails: Array<ExtraDetailsItemProps & IssuerInformationRef> = [
     {
-      title: 'Offering amount',
-      value: '-',
-      ...offeringSize,
-      tooltip: 'Number of bonds being sold.',
-    },
-    {
-      title: 'Total order volume',
-      value: '-',
-      ...totalBidVolume,
-      tooltip: 'Sum of all order volume.',
-    },
-    {
-      title: 'Min funding threshold',
-      tooltip:
-        'Minimum order volume required for auction to close. If this value is not reached, all funds will be returned and no bonds will be sold.',
-      value: '-',
-      ...minimumFundingThreshold,
-    },
-    {
-      title: 'Minimum order amount',
-      value: '-',
-      ...minimumBidSize,
-      tooltip: 'Minimum amount for a single order. Orders below this amount cannot be placed.',
-    },
-    {
       title: 'Current bond price',
       tooltip: `Current auction clearing price for a single auction. If the auction ended now, this would be the price set.`,
       value: '-',
       ...currentBondPrice,
       bordered: 'blue',
+      valueText: 'text-[#75ed02]',
     },
     {
       title: 'Current bond YTM',
@@ -202,6 +178,21 @@ const AuctionDetails = (props: Props) => {
       tooltip:
         'Current bond yield to maturity calculated from the current bond price. If the auction ended now, this is the return bond purchasers would receive assuming no default.',
       bordered: 'blue',
+      valueText: 'text-[#75ed02]',
+    },
+    {
+      title: 'Total order volume',
+      value: '-',
+      ...totalBidVolume,
+      tooltip: 'Sum of all order volume.',
+      bordered: 'blue',
+      valueText: 'text-[#75ed02]',
+    },
+    {
+      title: 'Offering amount',
+      value: '-',
+      ...offeringSize,
+      tooltip: 'Number of bonds being sold.',
     },
     {
       title: 'Minimum bond price',
@@ -215,6 +206,19 @@ const AuctionDetails = (props: Props) => {
       value: maxBondYTM,
       tooltip:
         'Maximum yield to maturity the issuer is willing to pay. This is calculated using the minimum bond price.',
+    },
+    {
+      title: 'Min funding threshold',
+      tooltip:
+        'Minimum order volume required for auction to close. If this value is not reached, all funds will be returned and no bonds will be sold.',
+      value: '-',
+      ...minimumFundingThreshold,
+    },
+    {
+      title: 'Minimum order amount',
+      value: '-',
+      ...minimumBidSize,
+      tooltip: 'Minimum amount for a single order. Orders below this amount cannot be placed.',
     },
   ]
 

--- a/src/components/auction/AuctionDetails/index.tsx
+++ b/src/components/auction/AuctionDetails/index.tsx
@@ -170,7 +170,7 @@ const AuctionDetails = (props: Props) => {
       value: '-',
       ...currentBondPrice,
       bordered: 'blue',
-      valueText: 'text-[#75ed02]',
+      valueText: 'text-[#09f50b]',
     },
     {
       title: 'Current bond YTM',
@@ -178,7 +178,7 @@ const AuctionDetails = (props: Props) => {
       tooltip:
         'Current bond yield to maturity calculated from the current bond price. If the auction ended now, this is the return bond purchasers would receive assuming no default.',
       bordered: 'blue',
-      valueText: 'text-[#75ed02]',
+      valueText: 'text-[#09f50b]',
     },
     {
       title: 'Total order volume',
@@ -186,7 +186,7 @@ const AuctionDetails = (props: Props) => {
       ...totalBidVolume,
       tooltip: 'Sum of all order volume.',
       bordered: 'blue',
-      valueText: 'text-[#75ed02]',
+      valueText: 'text-[#09f50b]',
     },
     {
       title: 'Offering amount',
@@ -236,7 +236,7 @@ const AuctionDetails = (props: Props) => {
           rightOfCountdown={
             auction?.bond.id in BOND_INFORMATION && (
               <button
-                className="btn-primary btn-sm btn space-x-2 rounded-md bg-[#293327] !text-xxs font-normal"
+                className="btn-primary btn-sm btn space-x-2 rounded-md bg-[#1C701C] !text-xxs font-normal"
                 onClick={() => navigate(`/bonds/${auction?.bond.id || ''}`)}
                 ref={props.issuerInformationRef}
               >

--- a/src/components/auction/AuctionSettle.tsx
+++ b/src/components/auction/AuctionSettle.tsx
@@ -15,7 +15,7 @@ const AuctionSettle = () => {
   const { settleAuctionCallback } = useSettleAuction(auctionId)
 
   return (
-    <div className="card place-order-color">
+    <div className="place-order-color card">
       <div className="card-body">
         <h2 className="card-title">Auction Settling</h2>
 
@@ -30,7 +30,7 @@ const AuctionSettle = () => {
         )}
         {!account && (
           <ActionButton className="mt-4" onClick={toggleWalletModal}>
-            Connect wallet
+            Connect Wallet
           </ActionButton>
         )}
       </div>
@@ -39,7 +39,7 @@ const AuctionSettle = () => {
         actionText="Settle auction"
         beforeDisplay={
           <div className="mt-10 space-y-6">
-            <h1 className="text-xl font-medium text-center text-[#E0E0E0]">Are you sure?</h1>
+            <h1 className="text-center text-xl font-medium text-[#E0E0E0]">Are you sure?</h1>
             <p className="overflow-hidden text-[#D6D6D6]">
               It is the responsibility of the auctioneer to settle the auction. Therefore, we
               recommend you wait for them to handle it. However, you have the option to settle the

--- a/src/components/auction/AuctionTour/index.tsx
+++ b/src/components/auction/AuctionTour/index.tsx
@@ -1,9 +1,10 @@
 import React, { RefObject, useState } from 'react'
 
-import { Button, Tour, TourStepProps } from 'antd'
+import { Tour, TourStepProps } from 'antd'
 import type { TourProps } from 'antd'
 
 import { TooltipIcon } from '../../icons/TooltipIcon'
+import { ActionButton } from '../Claimer'
 
 interface Props {
   auctionInformationRef: RefObject<HTMLHeadingElement>
@@ -163,9 +164,9 @@ const AuctionTour = (props: Props) => {
           <span>Need Help?</span>
         </h2>
         <>
-          <Button onClick={() => setOpen(true)} type="primary">
+          <ActionButton onClick={() => setOpen(true)} type="primary">
             Yes, Start the Walkthrough!
-          </Button>
+          </ActionButton>
           <Tour mask={true} onClose={() => setOpen(false)} open={open} steps={steps} />
         </>
       </div>

--- a/src/components/auction/Claimer/index.tsx
+++ b/src/components/auction/Claimer/index.tsx
@@ -34,7 +34,7 @@ const Wrapper = styled(BaseCard)`
 export const ActionButton = ({ children, color = 'blue', ...props }) => (
   <button
     {...props}
-    className={`btn btn-block btn-sm w-full normal-case hover:bg-[#1C701C]/80 ${
+    className={`btn-block btn-sm btn w-full normal-case hover:bg-[#1C701C]/80 ${
       props.disabled ? '!bg-[#2C2C2C] !text-[#696969]' : 'bg-[#1C701C] text-white'
     } h-[41px] font-normal ${color !== 'blue' && 'bg-[#293327] hover:bg-[#293327]/80'} ${
       props.className
@@ -47,7 +47,7 @@ export const ActionButton = ({ children, color = 'blue', ...props }) => (
 export const GhostActionLink = ({ children, ...props }) => (
   <a
     {...props}
-    className={`btn btn-link btn-block btn-sm w-full normal-case hover:bg-white hover:fill-black hover:text-black ${
+    className={`btn-link btn-block btn-sm btn w-full normal-case hover:bg-white hover:fill-black hover:text-black ${
       props.disabled ? '!bg-[#2C2C2C] !text-[#696969]' : 'bg-transparent text-white'
     } bordered h-[41px] border-[#2C2C2C] font-normal ${props.className}`}
   >
@@ -81,7 +81,7 @@ const ClaimDisabled = () => {
               : 'There are no funds to claim as you did not participate in the auction.'}
           </div>
 
-          {!account && <ActionButton onClick={toggleWalletModal}>Connect wallet</ActionButton>}
+          {!account && <ActionButton onClick={toggleWalletModal}>Connect Wallet</ActionButton>}
         </div>
       </div>
     </div>
@@ -190,7 +190,7 @@ const Claimer: React.FC<Props> = (props) => {
             </FieldRowLabelStyled>
           </div>
           {!account ? (
-            <ActionButton onClick={toggleWalletModal}>Connect wallet</ActionButton>
+            <ActionButton onClick={toggleWalletModal}>Connect Wallet</ActionButton>
           ) : (
             <ActionButton
               disabled={isClaimButtonDisabled}

--- a/src/components/auction/ExtraDetailsItem/index.tsx
+++ b/src/components/auction/ExtraDetailsItem/index.tsx
@@ -93,6 +93,7 @@ export interface Props {
   hint?: string | number | ReactElement
   fullNumberHint?: string
   value: string | number | ReactElement
+  valueText?: string
 }
 
 export const ExtraDetailsItem: React.FC<Props> = ({
@@ -106,12 +107,13 @@ export const ExtraDetailsItem: React.FC<Props> = ({
   tooltip,
   url,
   value,
+  valueText,
   ...restProps
 }) =>
   show && (
     <div className="col-span-1" {...restProps}>
       <div className="space-y-2">
-        <Value className={`${disabled ? 'text-[#696969]' : 'text-white'}`}>
+        <Value className={`${disabled ? 'text-[#696969]' : valueText ? valueText : 'text-white'}`}>
           <ValueText className="overflow-hidden text-ellipsis">{value || '-'}</ValueText>
           {url && <Link href={url} />}
           {hint && <span className="text-[#979797]">{hint}</span>}

--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -307,7 +307,7 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
           )}
           {!account && (
             <ActionButton className="mt-4" onClick={toggleWalletModal}>
-              Connect wallet
+              Connect Wallet
             </ActionButton>
           )}
         </div>
@@ -399,7 +399,7 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
               )}
               {!account ? (
                 <>
-                  <ActionButton onClick={toggleWalletModal}>Connect wallet</ActionButton>
+                  <ActionButton onClick={toggleWalletModal}>Connect Wallet</ActionButton>
                   <div className="mt-4 text-xs text-[#9F9F9F]">Wallet not connected</div>
                 </>
               ) : (

--- a/src/components/bond/BondAction/index.tsx
+++ b/src/components/bond/BondAction/index.tsx
@@ -378,7 +378,7 @@ const BondAction = ({
               {!account ? (
                 <>
                   <ActionButton color="blue" onClick={toggleWalletModal}>
-                    Connect wallet
+                    Connect Wallet
                   </ActionButton>
                   <div className="mt-4 text-xs text-[#9F9F9F]">Wallet not connected</div>
                 </>

--- a/src/components/bond/BondAction/index.tsx
+++ b/src/components/bond/BondAction/index.tsx
@@ -377,7 +377,7 @@ const BondAction = ({
 
               {!account ? (
                 <>
-                  <ActionButton color="purple" onClick={toggleWalletModal}>
+                  <ActionButton color="blue" onClick={toggleWalletModal}>
                     Connect wallet
                   </ActionButton>
                   <div className="mt-4 text-xs text-[#9F9F9F]">Wallet not connected</div>

--- a/src/pages/BondDetail/index.tsx
+++ b/src/pages/BondDetail/index.tsx
@@ -142,7 +142,7 @@ export const BondDetails = ({ id }) => {
           <BondDetailItem
             title="Documents"
             value={
-              <LinkIcon color={'#75ed02'} href={creditAnalysisArbor}>
+              <LinkIcon color={'#09f50b'} href={creditAnalysisArbor}>
                 Arbor Credit Analysis
               </LinkIcon>
             }

--- a/src/pages/BondDetail/index.tsx
+++ b/src/pages/BondDetail/index.tsx
@@ -203,7 +203,7 @@ export const BondDetails = ({ id }) => {
             <div className="cursor-pointer" onClick={() => setIsPromissoryModalOpen(true)}>
               <BondDetailItem
                 title="Signature"
-                value={<span className="text-[#6CADFB]">Promissory Note</span>}
+                value={<span className="text-[#09f50b]">Promissory Note</span>}
               />
             </div>
           </div>

--- a/src/pages/Portfolio/index.tsx
+++ b/src/pages/Portfolio/index.tsx
@@ -111,7 +111,7 @@ const Portfolio = () => {
     })) || []
   ).filter(({ type }) => (!tableFilter ? true : type === tableFilter))
 
-  const emptyActionText = account ? 'Go to offerings' : 'Connect wallet'
+  const emptyActionText = account ? 'Go to offerings' : 'Connect Wallet'
   const emptyActionClick = account ? () => navigate('/offerings') : toggleWalletModal
   const emptyDescription = account
     ? 'Your portfolio is empty'


### PR DESCRIPTION
Updated the shades of green across the frontend such that:

- [x] All emphasized text is the same shade of green as the logo
- [x] The action buttons and active status pill are all the same shade of green
- [x] Capitalize "W" in wallet

<img width="231" alt="image" src="https://user-images.githubusercontent.com/99197390/210637336-fb0778d6-9901-4371-a7c2-13032d643e6c.png">

<img width="835" alt="image" src="https://user-images.githubusercontent.com/99197390/210636793-5e5eb034-31b2-4e03-89f8-ecf39bf1ad3c.png">

<img width="803" alt="image" src="https://user-images.githubusercontent.com/99197390/210636833-7bddd341-5c79-4d2a-9c0c-5056bfbf1c3f.png">
